### PR TITLE
Some fixes and improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV DEBIAN_FRONTEND newt
 ADD scripts/start.sh /usr/local/sbin/start
 RUN chmod 755 /usr/local/sbin/start
 
-VOLUME ["/docker/keys", "/docker/incoming"]
+VOLUME ["/docker/keys", "/docker/incoming", "/repository"]
 
 EXPOSE 80
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 
 
 # Install supervisor for managing services
-RUN apt-get install -q -y supervisor cron openssh-server pwgen reprepro screen vim-tiny sudo nginx
+RUN apt-get install -q -y supervisor cron openssh-server pwgen reprepro screen vim-tiny nginx
 
 
 # Configure cron
@@ -31,10 +31,8 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD configs/nginx-default.conf /etc/nginx/sites-enabled/default
 
-# Setup root & sudo access
+# Setup root access
 RUN echo "root:docker" | chpasswd
-RUN echo %sudo  ALL=NOPASSWD: ALL >> /etc/sudoers
-
 
 # Configure supervisor
 RUN service supervisor stop
@@ -54,4 +52,3 @@ VOLUME ["/docker/keys", "/docker/incoming", "/repository"]
 EXPOSE 80
 EXPOSE 22
 CMD ["/usr/local/sbin/start"]
-

--- a/configs/nginx-default.conf
+++ b/configs/nginx-default.conf
@@ -2,7 +2,7 @@ server {
         listen 80 default_server;
         listen [::]:80 default_server ipv6only=on;
 
-        root /var/www;
+        root /repository/debian;
         index index.html index.htm;
 
         # Make site accessible from http://localhost/

--- a/scripts/reprepro-import.sh
+++ b/scripts/reprepro-import.sh
@@ -2,7 +2,7 @@
 
 BASEDIR=/var/lib/reprepro
 INCOMING=/docker/incoming
-OUTDIR=/var/www/debian
+OUTDIR=/repository/debian
 
 #
 # Make sure we're in the apt/ directory

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -28,13 +28,12 @@ chown -R user /home/user/.ssh
 # load cron
 CRONFILE=`mktemp`
 cat > $CRONFILE <<EOF
-* * * * * reprepro-import >> /var/log/reprepro.log
+* * * * * /usr/local/sbin/reprepro-import >> /var/log/reprepro.log
 EOF
 crontab -u root $CRONFILE
 rm -f $CRONFILE
 
 # run import once, to create the right directory structure
-reprepro-import
+/usr/local/sbin/reprepro-import
 
 supervisord -n
-

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,7 +8,7 @@
 # let's create a user to SSH into
 SSH_USERPASS=`pwgen -c -n -1 8`
 mkdir /home/user
-useradd -G sudo -d /home/user -s /bin/bash user 
+useradd -d /home/user -s /bin/bash user
 chown -R user /home/user
 chown -R user /docker/incoming
 	

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,13 +25,10 @@ for key in /docker/keys/*.pub ; do
 done
 chown -R user /home/user/.ssh
 
-# load cron
-CRONFILE=`mktemp`
-cat > $CRONFILE <<EOF
+# load crontab for root
+crontab <<EOF
 * * * * * /usr/local/sbin/reprepro-import >> /var/log/reprepro.log
 EOF
-crontab -u root $CRONFILE
-rm -f $CRONFILE
 
 # run import once, to create the right directory structure
 /usr/local/sbin/reprepro-import


### PR DESCRIPTION
  * Put full path in the crontab (else it can't find the script)
  * Setup the crontab with `crontab <<EOF` (strangely, `crontab -u root <<EOF` does not work)
  * Move the output directory (containing the important packages!!) to /repository/debian and expose it as a volume
  * Remove sudo access from 'user' (as it's not necessary; nsenter can get into the container for debugging).